### PR TITLE
Updated to use Quickstarts BOMs

### DIFF
--- a/boms/README.md
+++ b/boms/README.md
@@ -1,0 +1,23 @@
+JBoss Sandbox BOMs
+===================
+
+This folder contains BOMs (Bill of materials) used to help the build of Quickstarts using experimental features.
+
+_Note: These BOMs experimental and it is not supported. It contains non stable and experimental-features and its content and behaviour can be changed without any notice._
+ 
+Usage
+-----
+
+To use the BOM, import into your dependency management:
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+               <groupId>org.jboss.bom.sandbox</groupId>
+               <artifactId>jboss-javaee-6.0-with-all</artifactId>
+               <version>1.0.0-SNAPSHOT</version>
+               <type>pom</scope>
+               <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>

--- a/boms/jboss-javaee-6.0-with-drools/README.md
+++ b/boms/jboss-javaee-6.0-with-drools/README.md
@@ -1,0 +1,23 @@
+JBoss Java EE 6 with Drools Expert
+===================================
+
+This BOM builds on the Java EE full profile BOM, adding Drools.
+
+_Note: This BOM experimental and it is not supported. It may contain non stable and experimental-features and its content and behaviour can be changed without any notice._
+ 
+Usage
+-----
+ 
+To use the BOM, import into your dependency management:
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+               <groupId>org.jboss.bom.sandbox</groupId>
+               <artifactId>jboss-javaee-6.0-with-drools</artifactId>
+               <version>1.0.0-SNAPSHOT</version>
+               <type>pom</scope>
+               <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>

--- a/boms/jboss-javaee-6.0-with-drools/pom.xml
+++ b/boms/jboss-javaee-6.0-with-drools/pom.xml
@@ -1,0 +1,128 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    
+    <parent>
+        <groupId>org.jboss.bom.sandbox</groupId>
+        <version>1.0.0-SNAPSHOT</version>
+        <artifactId>jboss-sandbox-bom-parent</artifactId>
+    </parent>
+
+    <artifactId>jboss-javaee-6.0-with-drools</artifactId>
+    <packaging>pom</packaging>
+
+
+
+    <name>JBoss Java EE 6 Specification APIs with JBoss Drools</name>
+    <description>Dependency Management for Java EE 6 Specification APIs with JBoss Drools</description>
+
+    <url>http://www.jboss.org</url>
+    <scm>
+        <connection>scm:git:git@github.com:jboss-developer/jboss-brms-bom.git</connection>
+        <developerConnection>scm:git:git@github.com:jboss-developer/jboss-brms-bom.git</developerConnection>
+        <url>http://github.com/jboss-developer/jboss-brms-bom</url>
+    </scm>
+
+    <developers>
+        <developer>
+            <id>jboss.org</id>
+            <name>JBoss.org Community</name>
+            <organization>JBoss.org</organization>
+            <organizationUrl>http://www.jboss.org</organizationUrl>
+        </developer>
+    </developers>
+
+    <licenses>
+        <license>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+            <comments>A business-friendly OSS license</comments>
+        </license>
+    </licenses>
+
+    <properties>
+        <!-- Version properties are inherited from parent -->
+    </properties>
+
+    <dependencyManagement>
+
+        <dependencies>
+            <!-- JBoss distributes a complete set of Java EE 6 APIs including 
+                a Bill of Materials (BOM). A BOM specifies the versions of a "stack" (or 
+                a collection) of artifacts. We use this here so that we always get the correct 
+                versions of artifacts. Here we use the jboss-javaee-6.0 stack (you can read 
+                this as the JBoss stack of the Java EE full Profile 6 APIs), and we use version 
+                3.0.2.Final which is the latest release of the stack. You can actually use 
+                this stack with any version of JBoss AS that implements Java EE 6, not just 
+                JBoss AS 7! -->
+            <dependency>
+                <groupId>org.jboss.spec</groupId>
+                <artifactId>jboss-javaee-6.0</artifactId>
+                <version>${version.org.jboss.spec.jboss.javaee.6.0}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.drools</groupId>
+                <artifactId>knowledge-api</artifactId>
+                <version>${version.org.jboss.drools}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.drools</groupId>
+                <artifactId>drools-core</artifactId>
+                <version>${version.org.jboss.drools}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.drools</groupId>
+                <artifactId>drools-compiler</artifactId>
+                <version>${version.org.jboss.drools}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.drools.planner</groupId>
+                <artifactId>drools-planner-core</artifactId>
+                <version>${version.org.jboss.drools}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <distributionManagement>
+        <repository>
+            <id>jboss-releases-repository</id>
+            <name>JBoss Releases Repository</name>
+            <url>${jboss.releases.repo.url}</url>
+        </repository>
+        <snapshotRepository>
+            <id>jboss-snapshots-repository</id>
+            <name>JBoss Snapshots Repository</name>
+            <url>${jboss.snapshots.repo.url}</url>
+        </snapshotRepository>
+    </distributionManagement>
+
+    <profiles>
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>1.4</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+</project>

--- a/boms/jboss-javaee-6.0-with-security/README.md
+++ b/boms/jboss-javaee-6.0-with-security/README.md
@@ -1,0 +1,23 @@
+JBoss Java EE 6 with Security
+=============================
+
+This BOM builds on the Java EE full profile BOM, adding Picketlink.
+
+_Note: This BOM experimental and it is not supported. It may contain non stable and experimental-features and its content and behaviour can be changed without any notice._
+ 
+Usage
+-----
+
+To use the BOM, import into your dependency management:
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+               <groupId>org.jboss.bom.sandbox</groupId>
+               <artifactId>jboss-javaee-6.0-with-security</artifactId>
+               <version>1.0.0-SNAPSHOT</version>
+               <type>pom</type>
+               <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>

--- a/boms/jboss-javaee-6.0-with-security/pom.xml
+++ b/boms/jboss-javaee-6.0-with-security/pom.xml
@@ -1,0 +1,108 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.jboss.bom.sandbox</groupId>
+        <version>1.0.0-SNAPSHOT</version>
+        <artifactId>jboss-sandbox-bom-parent</artifactId>
+    </parent>
+
+    <artifactId>jboss-javaee-6.0-with-security</artifactId>
+    <packaging>pom</packaging>
+
+    <name>JBoss Java EE 6 Specification APIs with Security</name>
+    <description>Dependency Management for Java EE 6 Specification APIs with JBoss specific Security features. Currently included is JBoss Negotiation.</description>
+
+    <licenses>
+        <license>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <properties>
+        <!-- Version properties are inherited from parent -->
+    </properties>
+
+    <dependencyManagement>
+
+        <dependencies>
+            <!-- JBoss distributes a complete set of Java EE 6 APIs including 
+                a Bill of Materials (BOM). A BOM specifies the versions of a "stack" (or 
+                a collection) of artifacts. We use this here so that we always get the correct 
+                versions of artifacts. Here we use the jboss-javaee-6.0 stack (you can read 
+                this as the JBoss stack of the Java EE full Profile 6 APIs), and we use version 
+                3.0.2.Final which is the latest release of the stack. You can actually use 
+                this stack with any version of JBoss AS that implements Java EE 6, not just 
+                JBoss AS 7! -->
+            <dependency>
+                <groupId>org.jboss.spec</groupId>
+                <artifactId>jboss-javaee-6.0</artifactId>
+                <version>${version.org.jboss.spec.jboss.javaee.6.0}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+            <!-- JBoss Negotiation Dependencies -->
+            <dependency>
+                <groupId>org.jboss.security</groupId>
+                <artifactId>jboss-negotiation-common</artifactId>
+                <version>${version.org.jboss.security.negotiation}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.security</groupId>
+                <artifactId>jboss-negotiation-extras</artifactId>
+                <version>${version.org.jboss.security.negotiation}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.security</groupId>
+                <artifactId>jboss-negotiation-ntlm</artifactId>
+                <version>${version.org.jboss.security.negotiation}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.security</groupId>
+                <artifactId>jboss-negotiation-spnego</artifactId>
+                <version>${version.org.jboss.security.negotiation}</version>
+                <scope>provided</scope>
+            </dependency>
+            
+            <!-- PicketLink Dependencies -->
+            <dependency>
+                <groupId>org.picketlink</groupId>
+                <artifactId>picketlink-api</artifactId>
+                <version>${version.org.picketlink}</version>
+            </dependency>
+            
+            <dependency>
+                <groupId>org.picketlink</groupId>
+                <artifactId>picketlink-impl</artifactId>
+                <version>${version.org.picketlink}</version>
+            </dependency>
+            
+            <dependency>
+                <groupId>org.picketlink</groupId>
+                <artifactId>picketlink-idm-api</artifactId>
+                <version>${version.org.picketlink}</version>
+            </dependency>
+            
+            <dependency>
+                <groupId>org.picketlink</groupId>
+                <artifactId>picketlink-idm-impl</artifactId>
+                <version>${version.org.picketlink}</version>
+            </dependency>
+            
+            <dependency>
+                <groupId>org.picketlink</groupId>
+                <artifactId>picketlink-idm-simple-schema</artifactId>
+                <version>${version.org.picketlink}</version>
+            </dependency>
+
+        </dependencies>
+
+    </dependencyManagement>
+</project>

--- a/boms/pom.xml
+++ b/boms/pom.xml
@@ -1,0 +1,109 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.jboss.bom.sandbox</groupId>
+    <artifactId>jboss-sandbox-bom-parent</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+
+    <packaging>pom</packaging>
+
+    <name>JBoss Sandbox BOM Parent</name>
+    <description>Dependency Management BOM Parent</description>
+
+    <url>http://www.jboss.org</url>
+    <issueManagement>
+        <system>JIRA</system>
+        <url>https://issues.jboss.org/</url>
+    </issueManagement>
+
+    <scm>
+        <connection>scm:git:git@github.com:jboss-developer/jboss-sandbox-boms.git</connection>
+        <developerConnection>scm:git:git@github.com:jboss-developer/jboss-sandbox-boms.git</developerConnection>
+        <url>http://github.com/jboss-developer/jboss-sandbox-boms</url>
+    </scm>
+
+    <developers>
+        <developer>
+            <id>jboss.org</id>
+            <name>JBoss.org Community</name>
+            <organization>JBoss.org</organization>
+            <organizationUrl>http://www.jboss.org</organizationUrl>
+        </developer>
+    </developers>
+
+    <licenses>
+        <license>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <properties>
+      <!-- ############    E   A   P    P r o d u c t   V e r s i o n s  ############# -->
+        
+        <!-- JBoss projects -->
+        <version.org.jboss.security.negotiation>2.2.2.Final-redhat-1</version.org.jboss.security.negotiation>
+        <version.org.jboss.spec.jboss.javaee.6.0>3.0.2.Final-redhat-4</version.org.jboss.spec.jboss.javaee.6.0>
+
+        <!-- Picketlink -->
+        <version.org.picketlink>2.5.2.Final</version.org.picketlink>
+        
+        <!-- Drools -->
+        <version.org.jboss.drools>5.5.0.Final</version.org.jboss.drools>
+                
+        <!-- Repository Deployment URLs -->
+        <jboss.releases.repo.url>
+            https://repository.jboss.org/nexus/service/local/staging/deploy/maven2/
+        </jboss.releases.repo.url>
+        <jboss.snapshots.repo.url>
+            https://repository.jboss.org/nexus/content/repositories/snapshots/
+        </jboss.snapshots.repo.url>
+    </properties>
+
+    <modules>
+        <module>jboss-javaee-6.0-with-drools</module>
+        <module>jboss-javaee-6.0-with-security</module>
+    </modules>
+
+    <distributionManagement>
+        <repository>
+            <id>jboss-releases-repository</id>
+            <name>JBoss Releases Repository</name>
+            <url>${jboss.releases.repo.url}</url>
+        </repository>
+        <snapshotRepository>
+            <id>jboss-snapshots-repository</id>
+            <name>JBoss Snapshots Repository</name>
+            <url>${jboss.snapshots.repo.url}</url>
+        </snapshotRepository>
+    </distributionManagement>
+
+    <profiles>
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>1.4</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+</project>

--- a/kitchensink-angularjs-topcoat/pom.xml
+++ b/kitchensink-angularjs-topcoat/pom.xml
@@ -45,7 +45,7 @@
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
         <!-- Define the version of the JBoss BOMs we want to import. The 
             JBoss BOMs specify tested stacks. -->
-        <version.jboss.bom.eap>6.2.0-redhat-1</version.jboss.bom.eap>
+        <version.jboss.bom.eap>6.2.0-build-6</version.jboss.bom.eap>
         <!-- Alternatively, comment out the above line, and un-comment the 
             line below to use version 1.0.4.Final-redhat-4 which is a release certified 
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 

--- a/picketlink-authentication-form/pom.xml
+++ b/picketlink-authentication-form/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
          JBoss, Home of Professional Open Source
     Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
@@ -15,13 +15,12 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>org.jboss.quickstarts.eap</groupId>
+  <groupId>org.jboss.quickstarts.sandbox</groupId>
   <artifactId>jboss-as-picketlink-authentication-form</artifactId>
-  <version>6.2.0-redhat-SNAPSHOT</version>
+  <version>1.0.0-SNAPSHOT</version>
   <packaging>war</packaging>
   <name>JBoss EAP Quickstart: picketlink-authentication-form</name>
   <description>JBoss EAP Quickstarts: PicketLink FORM Authentication</description>
@@ -48,7 +47,7 @@
 
     <!-- Define the version of the JBoss BOMs we want to import to specify
                tested stacks. -->
-    <version.jboss.bom.eap>6.2.0-build-5</version.jboss.bom.eap>
+    <version.jboss.bom.sandbox>1.0.0-SNAPSHOT</version.jboss.bom.sandbox>
     <version.war.plugin>2.1.1</version.war.plugin>
 
     <!-- maven-compiler-plugin -->
@@ -60,9 +59,9 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>org.jboss.bom.eap</groupId>
+        <groupId>org.jboss.bom.sandbox</groupId>
         <artifactId>jboss-javaee-6.0-with-security</artifactId>
-        <version>${version.jboss.bom.eap}</version>
+        <version>${version.jboss.bom.sandbox}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/picketlink-authentication-http-basic/pom.xml
+++ b/picketlink-authentication-http-basic/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
     JBoss, Home of Professional Open Source
     Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
@@ -15,13 +15,12 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>org.jboss.quickstarts.eap</groupId>
+  <groupId>org.jboss.quickstarts.sandbox</groupId>
   <artifactId>jboss-as-picketlink-authentication-http-basic</artifactId>
-  <version>6.2.0-redhat-SNAPSHOT</version>
+  <version>1.0.0-SNAPSHOT</version>
   <packaging>war</packaging>
   <name>JBoss EAP Quickstart: picketlink-authentication-http-basic</name>
   <description>JBoss EAP Quickstart: PicketLink HTTP Basic Authentication</description>
@@ -48,7 +47,7 @@
 
     <!-- Define the version of the JBoss BOMs we want to import to specify 
       tested stacks. -->
-    <version.jboss.bom.eap>6.2.0-build-5</version.jboss.bom.eap>
+    <version.jboss.bom.sandbox>1.0.0-SNAPSHOT</version.jboss.bom.sandbox>
     <version.war.plugin>2.1.1</version.war.plugin>
 
     <!-- maven-compiler-plugin -->
@@ -60,9 +59,9 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>org.jboss.bom.eap</groupId>
+        <groupId>org.jboss.bom.sandbox</groupId>
         <artifactId>jboss-javaee-6.0-with-security</artifactId>
-        <version>${version.jboss.bom.eap}</version>
+        <version>${version.jboss.bom.sandbox}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/picketlink-authentication-http-client-cert/pom.xml
+++ b/picketlink-authentication-http-client-cert/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
     JBoss, Home of Professional Open Source
     Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
@@ -15,13 +15,12 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>org.jboss.quickstarts.eap</groupId>
+  <groupId>org.jboss.quickstarts.sandbox</groupId>
   <artifactId>jboss-as-picketlink-authentication-http-client-cert</artifactId>
-  <version>6.2.0-redhat-SNAPSHOT</version>
+  <version>1.0.0-SNAPSHOT</version>
   <packaging>war</packaging>
   <name>JBoss EAP Quickstart: picketlink-authentication-http-client-cert</name>
   <description>JBoss EAP Quickstarts: PicketLink HTTP CLIENT-CERT Authentication</description>
@@ -48,7 +47,7 @@
 
     <!-- Define the version of the JBoss BOMs we want to import to specify 
       tested stacks. -->
-    <version.jboss.bom.eap>6.2.0-build-5</version.jboss.bom.eap>
+    <version.jboss.bom.sandbox>1.0.0-SNAPSHOT</version.jboss.bom.sandbox>
     <version.war.plugin>2.1.1</version.war.plugin>
 
     <!-- maven-compiler-plugin -->
@@ -60,9 +59,9 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>org.jboss.bom.eap</groupId>
+        <groupId>org.jboss.bom.sandbox</groupId>
         <artifactId>jboss-javaee-6.0-with-security</artifactId>
-        <version>${version.jboss.bom.eap}</version>
+        <version>${version.jboss.bom.sandbox}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/picketlink-authentication-http-digest/pom.xml
+++ b/picketlink-authentication-http-digest/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
     JBoss, Home of Professional Open Source
     Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
@@ -15,13 +15,12 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>org.jboss.quickstarts.eap</groupId>
+  <groupId>org.jboss.quickstarts.sandbox</groupId>
   <artifactId>jboss-as-picketlink-authentication-http-digest</artifactId>
-  <version>6.2.0-redhat-SNAPSHOT</version>
+  <version>1.0.0-SNAPSHOT</version>
   <packaging>war</packaging>
   <name>JBoss EAP Quickstart: picketlink-authentication-http-digest</name>
   <description>JBoss EAP Quickstart: PicketLink HTTP Digest Authentication</description>
@@ -48,7 +47,7 @@
 
     <!-- Define the version of the JBoss BOMs we want to import to specify 
       tested stacks. -->
-    <version.jboss.bom.eap>6.2.0-build-5</version.jboss.bom.eap>
+    <version.jboss.bom.sandbox>1.0.0-SNAPSHOT</version.jboss.bom.sandbox>
     <version.war.plugin>2.1.1</version.war.plugin>
 
     <!-- maven-compiler-plugin -->
@@ -60,9 +59,9 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>org.jboss.bom.eap</groupId>
+        <groupId>org.jboss.bom.sandbox</groupId>
         <artifactId>jboss-javaee-6.0-with-security</artifactId>
-        <version>${version.jboss.bom.eap}</version>
+        <version>${version.jboss.bom.sandbox}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/picketlink-authentication-idm-jsf/pom.xml
+++ b/picketlink-authentication-idm-jsf/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
     JBoss, Home of Professional Open Source
     Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
@@ -15,13 +15,12 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>org.jboss.quickstarts.eap</groupId>
+  <groupId>org.jboss.quickstarts.sandbox</groupId>
   <artifactId>jboss-as-picketlink-authentication-idm-jsf</artifactId>
-  <version>6.2.0-redhat-SNAPSHOT</version>
+  <version>1.0.0-SNAPSHOT</version>
   <packaging>war</packaging>
   <name>JBoss EAP Quickstart: picketlink-authentication-idm-jsf</name>
   <description>JBoss EAP Quickstart: PicketLink IDM Simple Authentication with JSF</description>
@@ -48,7 +47,7 @@
 
     <!-- Define the version of the JBoss BOMs we want to import to specify 
       tested stacks. -->
-    <version.jboss.bom.eap>6.2.0-build-5</version.jboss.bom.eap>
+    <version.jboss.bom.sandbox>1.0.0-SNAPSHOT</version.jboss.bom.sandbox>
     <version.war.plugin>2.1.1</version.war.plugin>
 
     <!-- maven-compiler-plugin -->
@@ -60,9 +59,9 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>org.jboss.bom.eap</groupId>
+        <groupId>org.jboss.bom.sandbox</groupId>
         <artifactId>jboss-javaee-6.0-with-security</artifactId>
-        <version>${version.jboss.bom.eap}</version>
+        <version>${version.jboss.bom.sandbox}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/picketlink-authentication-idm-multi-tenancy/pom.xml
+++ b/picketlink-authentication-idm-multi-tenancy/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
     JBoss, Home of Professional Open Source
     Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
@@ -15,13 +15,12 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>org.jboss.quickstarts.eap</groupId>
+  <groupId>org.jboss.quickstarts.sandbox</groupId>
   <artifactId>jboss-as-picketlink-authentication-idm-multi-tenancy</artifactId>
-  <version>6.2.0-redhat-SNAPSHOT</version>
+  <version>1.0.0-SNAPSHOT</version>
   <packaging>war</packaging>
   <name>JBoss EAP Quickstart: picketlink-authentication-idm-multi-tenancy</name>
   <description>JBoss EAP Quickstart: PicketLink Multi-Tenancy Example</description>
@@ -48,7 +47,7 @@
 
     <!-- Define the version of the JBoss BOMs we want to import to specify 
       tested stacks. -->
-    <version.jboss.bom.eap>6.2.0-build-5</version.jboss.bom.eap>
+    <version.jboss.bom.sandbox>1.0.0-SNAPSHOT</version.jboss.bom.sandbox>
     <version.war.plugin>2.1.1</version.war.plugin>
 
     <!-- maven-compiler-plugin -->
@@ -60,9 +59,9 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>org.jboss.bom.eap</groupId>
+        <groupId>org.jboss.bom.sandbox</groupId>
         <artifactId>jboss-javaee-6.0-with-security</artifactId>
-        <version>${version.jboss.bom.eap}</version>
+        <version>${version.jboss.bom.sandbox}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/picketlink-authentication-jsf/pom.xml
+++ b/picketlink-authentication-jsf/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
     JBoss, Home of Professional Open Source
     Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
@@ -15,13 +15,12 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>org.jboss.quickstarts.eap</groupId>
+  <groupId>org.jboss.quickstarts.sandbox</groupId>
   <artifactId>jboss-as-picketlink-authentication-jsf</artifactId>
-  <version>6.2.0-redhat-SNAPSHOT</version>
+  <version>1.0.0-SNAPSHOT</version>
   <packaging>war</packaging>
   <name>JBoss EAP Quickstart: picketlink-authentication-jsf</name>
   <description>JBoss EAP Quickstart: PicketLink Authentication with JSF</description>
@@ -47,7 +46,7 @@
     <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
 
     <!-- Define the version of the JBoss BOMs we want to import to specify tested stacks. -->
-    <version.jboss.bom.eap>6.2.0-build-5</version.jboss.bom.eap>
+    <version.jboss.bom.sandbox>1.0.0-SNAPSHOT</version.jboss.bom.sandbox>
 
     <!-- other plugin versions -->
     <version.war.plugin>2.1.1</version.war.plugin>
@@ -61,9 +60,9 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>org.jboss.bom.eap</groupId>
+        <groupId>org.jboss.bom.sandbox</groupId>
         <artifactId>jboss-javaee-6.0-with-security</artifactId>
-        <version>${version.jboss.bom.eap}</version>
+        <version>${version.jboss.bom.sandbox}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/picketlink-authentication-recaptcha/pom.xml
+++ b/picketlink-authentication-recaptcha/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
     JBoss, Home of Professional Open Source
     Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
@@ -15,13 +15,12 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>org.jboss.quickstarts.eap</groupId>
+  <groupId>org.jboss.quickstarts.sandbox</groupId>
   <artifactId>jboss-as-picketlink-authentication-recaptcha</artifactId>
-  <version>6.2.0-redhat-SNAPSHOT</version>
+  <version>1.0.0-SNAPSHOT</version>
   <packaging>war</packaging>
   <name>JBoss EAP Quickstart: picketlink-authentication-recaptcha</name>
   <description>JBoss EAP Quickstarts: PicketLink Authentication using reCAPTCHA</description>
@@ -48,7 +47,8 @@
 
     <!-- Define the version of the JBoss BOMs we want to import to specify 
       tested stacks. -->
-    <version.jboss.bom.eap>6.2.0-build-5</version.jboss.bom.eap>
+    <version.jboss.bom.eap>6.2.0-build-6</version.jboss.bom.eap>
+    <version.jboss.bom.sandbox>1.0.0-SNAPSHOT</version.jboss.bom.sandbox>
     <version.war.plugin>2.1.1</version.war.plugin>
 
     <!-- maven-compiler-plugin -->
@@ -63,9 +63,9 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>org.jboss.bom.eap</groupId>
+        <groupId>org.jboss.bom.sandbox</groupId>
         <artifactId>jboss-javaee-6.0-with-security</artifactId>
-        <version>${version.jboss.bom.eap}</version>
+        <version>${version.jboss.bom.sandbox}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/picketlink-authentication-rs-endpoint/pom.xml
+++ b/picketlink-authentication-rs-endpoint/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
     JBoss, Home of Professional Open Source
     Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
@@ -15,13 +15,12 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>org.jboss.quickstarts.eap</groupId>
+  <groupId>org.jboss.quickstarts.sandbox</groupId>
   <artifactId>jboss-as-picketlink-authentication-rs-endpoint</artifactId>
-  <version>6.2.0-redhat-SNAPSHOT</version>
+  <version>1.0.0-SNAPSHOT</version>
   <packaging>war</packaging>
   <name>JBoss EAP Quickstart: picketlink-authentication-rs-endpoint</name>
   <description>JBoss EAP Quickstart: PicketLink JAX-RS Authentication Endpoint</description>
@@ -48,7 +47,7 @@
 
     <!-- Define the version of the JBoss BOMs we want to import to specify 
       tested stacks. -->
-    <version.jboss.bom.eap>6.2.0-build-5</version.jboss.bom.eap>
+    <version.jboss.bom.sandbox>1.0.0-SNAPSHOT</version.jboss.bom.sandbox>
     <version.war.plugin>2.1.1</version.war.plugin>
 
     <!-- maven-compiler-plugin -->
@@ -60,9 +59,9 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>org.jboss.bom.eap</groupId>
+        <groupId>org.jboss.bom.sandbox</groupId>
         <artifactId>jboss-javaee-6.0-with-security</artifactId>
-        <version>${version.jboss.bom.eap}</version>
+        <version>${version.jboss.bom.sandbox}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/picketlink-authentication-two-factor/pom.xml
+++ b/picketlink-authentication-two-factor/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
     JBoss, Home of Professional Open Source
     Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
@@ -15,13 +15,12 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>org.jboss.quickstarts.eap</groupId>
+  <groupId>org.jboss.quickstarts.sandbox</groupId>
   <artifactId>jboss-as-picketlink-authentication-two-factor</artifactId>
-  <version>6.2.0-redhat-SNAPSHOT</version>
+  <version>1.0.0-SNAPSHOT</version>
   <packaging>war</packaging>
   <name>JBoss EAP Quickstart: picketlink-authentication-two-factor</name>
   <description>JBoss EAP Quickstart: PicketLink Two-Factor Authentication</description>
@@ -48,7 +47,7 @@
 
     <!-- Define the version of the JBoss BOMs we want to import to specify 
       tested stacks. -->
-    <version.jboss.bom.eap>6.2.0-build-5</version.jboss.bom.eap>
+    <version.jboss.bom.sandbox>1.0.0-SNAPSHOT</version.jboss.bom.sandbox>
     <version.war.plugin>2.1.1</version.war.plugin>
 
     <!-- maven-compiler-plugin -->
@@ -60,9 +59,9 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>org.jboss.bom.eap</groupId>
+        <groupId>org.jboss.bom.sandbox</groupId>
         <artifactId>jboss-javaee-6.0-with-security</artifactId>
-        <version>${version.jboss.bom.eap}</version>
+        <version>${version.jboss.bom.sandbox}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/picketlink-authorization-idm-jpa/pom.xml
+++ b/picketlink-authorization-idm-jpa/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
     JBoss, Home of Professional Open Source
     Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
@@ -15,11 +15,10 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>org.jboss.quickstarts.eap</groupId>
+  <groupId>org.jboss.quickstarts.sandbox</groupId>
   <artifactId>jboss-as-picketlink-authorization-idm-jpa</artifactId>
   <version>6.2.0-redhat-SNAPSHOT</version>
   <packaging>war</packaging>
@@ -48,7 +47,7 @@
 
     <!-- Define the version of the JBoss BOMs we want to import to specify 
       tested stacks. -->
-    <version.jboss.bom.eap>6.2.0-build-5</version.jboss.bom.eap>
+    <version.jboss.bom.sandbox>1.0.0-SNAPSHOT</version.jboss.bom.sandbox>
 
     <!-- other plugin versions -->
     <version.war.plugin>2.1.1</version.war.plugin>
@@ -62,9 +61,9 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>org.jboss.bom.eap</groupId>
+        <groupId>org.jboss.bom.sandbox</groupId>
         <artifactId>jboss-javaee-6.0-with-security</artifactId>
-        <version>${version.jboss.bom.eap}</version>
+        <version>${version.jboss.bom.sandbox}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/picketlink-authorization-idm-ldap/pom.xml
+++ b/picketlink-authorization-idm-ldap/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
     JBoss, Home of Professional Open Source
     Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
@@ -15,13 +15,12 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>org.jboss.quickstarts.eap</groupId>
+  <groupId>org.jboss.quickstarts.sandbox</groupId>
   <artifactId>jboss-as-picketlink-authorization-idm-ldap</artifactId>
-  <version>6.2.0-redhat-SNAPSHOT</version>
+  <version>1.0.0-SNAPSHOT</version>
   <packaging>war</packaging>
   <name>JBoss EAP Quickstart: picketlink-authorization-idm-ldap</name>
   <description>JBoss EAP Quickstarts: PicketLink IDM Authorization using LDAP</description>
@@ -48,7 +47,8 @@
 
     <!-- Define the version of the JBoss BOMs we want to import to specify 
       tested stacks. -->
-    <version.jboss.bom.eap>6.2.0-build-5</version.jboss.bom.eap>
+    <version.jboss.bom.sandbox>1.0.0-SNAPSHOT</version.jboss.bom.sandbox>
+    <version.jboss.bom.eap>6.2.0-build-6</version.jboss.bom.eap>
     <version.war.plugin>2.1.1</version.war.plugin>
 
     <!-- Defines the version of the ApacheDS Embedded -->
@@ -62,9 +62,9 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>org.jboss.bom.eap</groupId>
+        <groupId>org.jboss.bom.sandbox</groupId>
         <artifactId>jboss-javaee-6.0-with-security</artifactId>
-        <version>${version.jboss.bom.eap}</version>
+        <version>${version.jboss.bom.sandbox}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/picketlink-authorization-rs-rbac/pom.xml
+++ b/picketlink-authorization-rs-rbac/pom.xml
@@ -19,9 +19,9 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>org.jboss.quickstarts.wfk</groupId>
+  <groupId>org.jboss.quickstarts.sandbox</groupId>
   <artifactId>jboss-as-picketlink-authorization-rs-rbac</artifactId>
-  <version>2.4.0-build-SNAPSHOT</version>
+  <version>1.0.0-SNAPSHOT</version>
   <packaging>war</packaging>
   <name>JBoss WFK Quickstart: picketlink-authorization-rs-rbac</name>
   <description>JBoss WFK Quickstart: PicketLink Role-based Access Control(RBAC) for JAX-RS Endpoints</description>
@@ -46,11 +46,8 @@
 
     <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
 
-    <!-- Define the version of the JBoss EAP BOMs we want to import to specify
-      tested stacks. -->
-    <version.jboss.bom.eap>1.0.7.Final</version.jboss.bom.eap>
-
     <!-- Define the version of the JBoss WFK BOMs we want to import to specify tested stacks. -->
+    <version.jboss.bom.sandbox>1.0.0-SNAPSHOT</version.jboss.bom.sandbox>
     <version.jboss.bom.wfk>2.4.0-build-5</version.jboss.bom.wfk>
 
     <version.war.plugin>2.1.1</version.war.plugin>
@@ -62,22 +59,22 @@
   </properties>
 
   <dependencyManagement>
+    <!-- JBoss distributes a complete set of Java EE 6 APIs including
+     a Bill of Materials (BOM). A BOM specifies the versions of a "stack" (or
+     a collection) of artifacts. We use this here so that we always get the correct
+     versions of artifacts. Here we use the jboss-javaee-6.0-with-deltaspike stack
+     (you can read this as the JBoss stack of the Java EE 6 APIs with Deltaspike).
+     You can actually use this stack with any version of JBoss AS that implements
+     Java EE 6, not just JBoss AS 7! -->
     <dependencies>
       <dependency>
-        <groupId>org.jboss.bom</groupId>
+        <groupId>org.jboss.bom.sandbox</groupId>
         <artifactId>jboss-javaee-6.0-with-security</artifactId>
-        <version>${version.jboss.bom.eap}</version>
+        <version>${version.jboss.bom.sandbox}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
 
-  <!-- JBoss distributes a complete set of Java EE 6 APIs including
-   a Bill of Materials (BOM). A BOM specifies the versions of a "stack" (or
-   a collection) of artifacts. We use this here so that we always get the correct
-   versions of artifacts. Here we use the jboss-javaee-6.0-with-deltaspike stack
-   (you can read this as the JBoss stack of the Java EE 6 APIs with Deltaspike).
-   You can actually use this stack with any version of JBoss AS that implements
-   Java EE 6, not just JBoss AS 7! -->
       <dependency>
         <groupId>org.jboss.bom.wfk</groupId>
         <artifactId>jboss-javaee-6.0-with-deltaspike</artifactId>

--- a/picketlink-deltaspike-authorization/pom.xml
+++ b/picketlink-deltaspike-authorization/pom.xml
@@ -49,7 +49,7 @@
     <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
 
     <!-- Define the version of the JBoss EAP BOMs we want to import to specify tested stacks. -->
-    <version.jboss.bom.eap>1.0.7.Final</version.jboss.bom.eap>
+    <version.jboss.bom.sandbox>1.0.0-SNAPSHOT</version.jboss.bom.sandbox>
 
     <!-- Define the version of the JBoss WFK BOMs we want to import to specify tested stacks. -->
     <version.jboss.bom.wfk>2.4.0-build-5</version.jboss.bom.wfk>
@@ -79,9 +79,9 @@
       </dependency>
 
       <dependency>
-        <groupId>org.jboss.bom</groupId>
+        <groupId>org.jboss.bom.sandbox</groupId>
         <artifactId>jboss-javaee-6.0-with-security</artifactId>
-        <version>${version.jboss.bom.eap}</version>
+        <version>${version.jboss.bom.sandbox}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,176 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.jboss</groupId>
+        <artifactId>jboss-parent</artifactId>
+        <version>8</version>
+        <relativePath />
+    </parent>
+    <groupId>org.jboss.quickstarts.eap</groupId>
+    
+    <artifactId>jboss-sandbox-quickstarts-parent</artifactId>
+    <version>1.0.0-build-SNAPSHOT</version>
+    <packaging>pom</packaging>
+    <name>JBoss Sandbox Quickstart: Parent</name>
+    <description>JBoss Sandbox Quickstarts Parent</description>
+    <url>http://www.jboss.org/jdf/quickstarts/get-started/</url>
+
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <distribution>repo</distribution>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+        </license>
+    </licenses>
+
+    <properties>
+        <!-- A base list of dependency and plugin version used in the various quick starts. -->
+
+        <!-- JBoss dependency versions -->
+
+        <version.jboss.as>7.2.1.Final-redhat-10</version.jboss.as>
+
+        <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
+
+        <!-- Define the version of the JBoss BOMs we want to import to specify tested stacks. -->
+        <version.jboss.bom.eap>6.2.0-build-4</version.jboss.bom.eap>
+
+        <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-4</version.jboss.spec.javaee.6.0>
+
+        <version.org.hibernate3.commons.annotations>3.2.0.Final</version.org.hibernate3.commons.annotations>
+        <version.org.hibernate>3.6.8.Final</version.org.hibernate>
+        <version.org.hibernate.em>3.6.8.Final</version.org.hibernate.em>
+        <version.org.hibernate.infinispan>3.6.8.Final</version.org.hibernate.infinispan>
+        
+        <!-- This is used in the hibernate-3 quickstart and requires the Hibernate 3 libraries -->
+        <!-- <version.org.hibernate.validator>4.2.0.Final</version.org.hibernate.validator> -->
+        <version.org.hibernate.validator>3.1.0.GA</version.org.hibernate.validator>
+                        
+        <!-- Other dependency versions -->
+        <version.org.apache.httpcomponents>4.1.4</version.org.apache.httpcomponents>
+        <version.dom4j>1.6</version.dom4j>
+        <version.javax.servlet.jstl>1.2</version.javax.servlet.jstl>
+        <version.log4j>1.2.16</version.log4j>
+        <version.org.apache.wicket>6.9.1</version.org.apache.wicket>
+        <version.net.ftlines.wicket-cdi>6.0</version.net.ftlines.wicket-cdi>
+
+        <!-- other plugin versions -->
+        <version.bundle.plugin>2.3.4</version.bundle.plugin>
+        <version.com.mycyla.license>2.5</version.com.mycyla.license>
+        <version.compiler.plugin>3.1</version.compiler.plugin>
+        <version.ear.plugin>2.8</version.ear.plugin>
+        <version.ejb.plugin>2.3</version.ejb.plugin>
+        <version.exec.plugin>1.2.1</version.exec.plugin>
+        <version.jar.plugin>2.2</version.jar.plugin>
+        <version.surefire.plugin>2.10</version.surefire.plugin>
+        <version.war.plugin>2.1.1</version.war.plugin>
+
+        <!-- maven-compiler-plugin -->
+        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.source>1.6</maven.compiler.source>
+    </properties>
+
+    <build>
+        <plugins>
+            <!-- The JBoss AS plugin deploys your apps to a local JBoss AS container -->
+            <!-- Disabling it here means that we don't try to deploy this POM! -->
+            <plugin>
+                <groupId>org.jboss.as.plugins</groupId>
+                <artifactId>jboss-as-maven-plugin</artifactId>
+                <version>${version.jboss.maven.plugin}</version>
+                <inherited>true</inherited>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <version>${version.com.mycyla.license}</version>
+                <configuration>
+                    <header>${basedir}/dist/license.txt</header>
+                    <aggregate>true</aggregate>
+                    <strictCheck>true</strictCheck>
+                    <excludes>
+                        <exclude>target/**</exclude>
+                        <exclude>.clover/**</exclude>
+                        <exclude>**/*.sql</exclude>
+                        <exclude>**/LICENSE*</exclude>
+                        <exclude>>**/license*</exclude>
+                        <!-- Exclude specific Quickstarts -->
+                        <exclude>petclinic-spring/**</exclude>
+                        <!-- Javascrip Libraries -->
+                        <exclude>**/jquery*</exclude>
+                        <exclude>**/angular*</exclude>
+                        <exclude>**/qunit*</exclude>
+                        <exclude>**/backbone*</exclude>
+                        <exclude>**/lodash*</exclude>
+                        <exclude>**/modernizr*</exclude>
+                        <exclude>**/yepnope*</exclude>
+                        <exclude>**/mobile-nav*</exclude>
+                        <!--Other libraries -->
+                        <exclude>**/*glyphicons*/**</exclude>
+                        <exclude>**/*cordova*/**</exclude>
+                    </excludes>
+                    <encoding>UTF-8</encoding>
+                    <headerDefinitions>
+                        <headerDefinition>dist/headerdefinition.xml</headerDefinition>
+                    </headerDefinitions>
+                </configuration>
+              </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <!-- All the quickstarts that require Postgres to be running -->
+            <id>default</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+                <property>
+                    <name>default</name>
+                    <value>!disabled</value>
+                </property>
+            </activation>
+            <modules>
+                <!-- All the modules that require nothing but JBoss Enterprise
+                    Application Platform -->
+                <module>boms</module>
+                <module>kitchensink-angularjs-topcoat</module>
+                <module>picketlink-authentication-form</module>
+                <module>picketlink-authentication-http-basic</module>
+                <module>picketlink-authentication-http-client-cert</module>
+                <module>picketlink-authentication-http-digest</module>
+                <module>picketlink-authentication-idm-jsf</module>
+                <module>picketlink-authentication-idm-multi-tenancy</module>
+                <module>picketlink-authentication-jsf</module>
+                <module>picketlink-authentication-recaptcha</module>
+                <module>picketlink-authentication-rs-endpoint</module>
+                <module>picketlink-authentication-two-factor</module>
+                <module>picketlink-authorization-idm-jpa</module>
+                <module>picketlink-authorization-idm-ldap</module>
+                <module>picketlink-authorization-rs-rbac</module>
+                <module>picketlink-deltaspike-authorization</module>
+            </modules>
+        </profile>
+    </profiles>
+
+</project>


### PR DESCRIPTION
Included:
- with-drools
- with-security PL 2.5

to BOMs

Update Picketlink Quickstarts GAV and -with-security BOMs to use Sandbox
